### PR TITLE
Do not display full license list

### DIFF
--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -616,13 +616,6 @@ namespace DepotDownloader
 
             Console.WriteLine( "Got {0} licenses for account!", licenseList.LicenseList.Count );
             Licenses = licenseList.LicenseList;
-
-            IEnumerable<uint> licenseQuery = Licenses.Select( lic =>
-            {
-                return lic.PackageID;
-            } );
-
-            Console.WriteLine( "Licenses: {0}", string.Join( ", ", licenseQuery ) );
         }
 
         private void UpdateMachineAuthCallback( SteamUser.UpdateMachineAuthCallback machineAuth )


### PR DESCRIPTION
Every time I run depot downloader, it bombards me with the license list, and when you have several thousands of them, it seems a bit silly.