### PR TITLE
Fix crashing on duplicate license

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -121,7 +121,7 @@ namespace DepotDownloader
             }
             else
             {
-                licenseQuery = steam3.Licenses.Select( x => x.PackageID );
+                licenseQuery = steam3.Licenses.Select( x => x.PackageID ).Distinct();
             }
 
             steam3.RequestPackageInfo( licenseQuery );


### PR DESCRIPTION
My bot owns some packageid twice, so it crashed here:

https://github.com/SteamRE/DepotDownloader/blob/90dfd03b5e5f66a349384b5b4867fe2ea856cb0f/DepotDownloader/Steam3Session.cs#L225

This crash would be fixed in next SK2 release, but might as well fix it here too.