### PR TITLE
-loginid option to support concurrent DepotDownload sessions

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -349,7 +349,7 @@ namespace DepotDownloader
                     Password = loginKey == null ? password : null,
                     ShouldRememberPassword = Config.RememberPassword,
                     LoginKey = loginKey,
-                    LoginID = 0x534B32, // "SK2"
+                    LoginID = Config.LoginID ?? 0x534B32, // "SK2"
                 }
             );
 

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -25,5 +25,8 @@ namespace DepotDownloader
 
         public string SuppliedPassword { get; set; }
         public bool RememberPassword { get; set; }
+
+        // A Steam LoginID to allow multiple concurrent connections
+        public uint? LoginID {get; set; }
     }
 }

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -83,6 +83,7 @@ namespace DepotDownloader
             ContentDownloader.Config.MaxServers = GetParameter<int>( args, "-max-servers", 20 );
             ContentDownloader.Config.MaxDownloads = GetParameter<int>( args, "-max-downloads", 4 );
             ContentDownloader.Config.MaxServers = Math.Max( ContentDownloader.Config.MaxServers, ContentDownloader.Config.MaxDownloads );
+            ContentDownloader.Config.LoginID = HasParameter( args, "-loginid" ) ? (uint?)GetParameter<uint>( args, "-loginid" ) : null;
 
             #endregion
 
@@ -285,6 +286,7 @@ namespace DepotDownloader
             Console.WriteLine( "\t-cellid <#>\t\t\t\t- the overridden CellID of the content server to download from." );
             Console.WriteLine( "\t-max-servers <#>\t\t- maximum number of content servers to use. (default: 8)." );
             Console.WriteLine( "\t-max-downloads <#>\t\t- maximum number of chunks to download concurrently. (default: 4)." );
+            Console.WriteLine( "\t-loginid <#>\t\t- a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently." );
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ Parameters:
 	-cellid <#>				- the overridden CellID of the content server to download from.
 	-max-servers <#>		- maximum number of content servers to use. (default: 8).
 	-max-downloads <#>		- maximum number of chunks to download concurrently. (default: 4).
+	-loginid <#>            - a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently.
 ```


### PR DESCRIPTION
# Problem
Currently the hardcoded value "SK2" is used for all instances of DepotDownloader for the LoginID option for every Steam logon session. When multiple concurrent logon sessions are used, sometimes Steam will drop connections with conflicting LoginIDs. This makes it impossible to run multiple parallel instances of DepotDownloader to download specific depots using the `-app` and `-depot` options.

XREF: https://github.com/SteamRE/DepotDownloader/issues/79

# Solution
The `-loginid` console option is added to allow users to manually specify a unique loginid for that instance of depot downloader. This allows external applications to manage concurrent Steam connections without conflict.