### PR TITLE
Added parameters for setting architecture, language and low violence for apps

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -386,7 +386,7 @@ namespace DepotDownloader
 
             if ( details.hcontent_file > 0 )
             {
-                await DownloadAppAsync( details.consumer_appid, details.consumer_appid, details.hcontent_file, DEFAULT_BRANCH, null, null, false, true );
+                await DownloadAppAsync( details.consumer_appid, details.consumer_appid, details.hcontent_file, DEFAULT_BRANCH, null, null, null, false, true );
             }
             else
             {
@@ -394,7 +394,7 @@ namespace DepotDownloader
             }
         }
 
-        public static async Task DownloadAppAsync( uint appId, uint depotId, ulong manifestId, string branch, string os, string language, bool lv, bool isUgc )
+        public static async Task DownloadAppAsync( uint appId, uint depotId, ulong manifestId, string branch, string os, string arch, string language, bool lv, bool isUgc )
         {
             // Load our configuration data containing the depots currently installed
             string configPath = ContentDownloader.Config.InstallDirectory;
@@ -462,6 +462,14 @@ namespace DepotDownloader
                                 {
                                     var oslist = depotConfig["oslist"].Value.Split( ',' );
                                     if ( Array.IndexOf( oslist, os ?? Util.GetSteamOS() ) == -1 )
+                                        continue;
+                                }
+
+                                if ( depotConfig["osarch"] != KeyValue.Invalid &&
+                                    !string.IsNullOrWhiteSpace( depotConfig["osarch"].Value ) )
+                                {
+                                    var depotArch = depotConfig["osarch"].Value;
+                                    if ( depotArch != ( arch ?? Util.GetSteamArch() ) )
                                         continue;
                                 }
 

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -7,6 +7,7 @@ namespace DepotDownloader
     {
         public int CellID { get; set; }
         public bool DownloadAllPlatforms { get; set; }
+        public bool DownloadAllLanguages { get; set; }
         public bool DownloadManifestOnly { get; set; }
         public string InstallDirectory { get; set; }
 

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -165,6 +165,16 @@ namespace DepotDownloader
                     Console.WriteLine("Error: Cannot specify -os when -all-platforms is specified.");
                     return 1;
                 }
+                ContentDownloader.Config.DownloadAllLanguages = HasParameter( args, "-all-languages" );
+                string language = GetParameter<string>( args, "-language", null );
+
+                if ( ContentDownloader.Config.DownloadAllLanguages && !String.IsNullOrEmpty( language ) )
+                {
+                    Console.WriteLine( "Error: Cannot specify -language when -all-languages is specified." );
+                    return 1;
+                }
+
+                bool lv = HasParameter( args, "-lowviolence" );
 
                 uint appId = GetParameter<uint>( args, "-app", ContentDownloader.INVALID_APP_ID );
                 if ( appId == ContentDownloader.INVALID_APP_ID )
@@ -197,7 +207,7 @@ namespace DepotDownloader
                 {
                     try
                     {
-                        await ContentDownloader.DownloadAppAsync( appId, depotId, manifestId, branch, os, isUGC ).ConfigureAwait( false );
+                        await ContentDownloader.DownloadAppAsync( appId, depotId, manifestId, branch, os, language, lv, isUGC ).ConfigureAwait( false );
                     }
                     catch ( Exception ex ) when (
                         ex is ContentDownloaderException

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -322,6 +322,10 @@ namespace DepotDownloader
             Console.WriteLine( "\t-betapassword <pass>\t\t- branch password if applicable." );
             Console.WriteLine( "\t-all-platforms\t\t\t- downloads all platform-specific depots when -app is used." );
             Console.WriteLine( "\t-os <os>\t\t\t\t- the operating system for which to download the game (windows, macos or linux, default: OS the program is currently running on)" );
+            Console.WriteLine( "\t-osarch <arch>\t\t\t\t- the architecture for which to download the game (32 or 64, default: the host's architecture)" );
+            Console.WriteLine( "\t-all-languages\t\t\t\t- download all language-specific depots when -app is used." );
+            Console.WriteLine( "\t-language <lang>\t\t\t\t- the language for which to download the game (default: english)" );
+            Console.WriteLine( "\t-lowviolence\t\t\t\t- download low violence depots when -app is used." );
             Console.WriteLine();
             Console.WriteLine( "\t-pubfile <#>\t\t\t- the PublishedFileId to download. (Will automatically resolve to UGC id)" );
             Console.WriteLine();

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -165,6 +165,9 @@ namespace DepotDownloader
                     Console.WriteLine("Error: Cannot specify -os when -all-platforms is specified.");
                     return 1;
                 }
+
+                string arch = GetParameter<string>( args, "-osarch", null );
+
                 ContentDownloader.Config.DownloadAllLanguages = HasParameter( args, "-all-languages" );
                 string language = GetParameter<string>( args, "-language", null );
 
@@ -207,7 +210,7 @@ namespace DepotDownloader
                 {
                     try
                     {
-                        await ContentDownloader.DownloadAppAsync( appId, depotId, manifestId, branch, os, language, lv, isUGC ).ConfigureAwait( false );
+                        await ContentDownloader.DownloadAppAsync( appId, depotId, manifestId, branch, os, arch, language, lv, isUGC ).ConfigureAwait( false );
                     }
                     catch ( Exception ex ) when (
                         ex is ContentDownloaderException

--- a/DepotDownloader/Util.cs
+++ b/DepotDownloader/Util.cs
@@ -28,6 +28,11 @@ namespace DepotDownloader
             return "unknown";
         }
 
+        public static string GetSteamArch()
+        {
+            return Environment.Is64BitOperatingSystem ? "64" : "32";
+        }
+
         public static string ReadPassword()
         {
             ConsoleKeyInfo keyInfo;


### PR DESCRIPTION
This covers the rest of depot mounting rules seen here: https://partner.steamgames.com/doc/store/application/depots#depot_mounting_rules This way, DepotDownloader won't always download all languages, all architectures and low violence depots.

New parameters:
* -language - sets the language for downloaded app (default: english).
* -all-languages - downloads all language specific depots for the app.
* -osarch - sets the architecture for downloaded app (32 or 64, default: host OS architecture). No option for all architectures since those depots usually contain same filenames so you'll just get the files from whatever depot is mounted second. Unfortunately, I cannot test this once since there are only like 20 apps that use this config option and I don't own any of them.
* -lowviolence - includes low violence depots for downloaded app. Normally, these are only downloaded if the app is provided by a package that enables low violence. Now that I think about it, maybe I should change the default behavior to be based on your packages like under Steam and have the parameter act like an override?