### PR TITLE
Various manifest related improvements

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -654,7 +654,7 @@ namespace DepotDownloader
                 }
                 else
                 {
-                    var newManifestFileName = Path.Combine( configDir, string.Format( "{0}.bin", depot.manifestId ) );
+                    var newManifestFileName = Path.Combine( configDir, string.Format( "{0}_{1}.bin", depot.id, depot.manifestId ) );
                     if ( newManifestFileName != null )
                     {
                         byte[] expectedChecksum, currentChecksum;

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -738,10 +738,13 @@ namespace DepotDownloader
 
                 newProtoManifest.Files.Sort( ( x, y ) => string.Compare( x.FileName, y.FileName, StringComparison.Ordinal ) );
 
+                Console.WriteLine( "Manifest {0} ({1})", depot.manifestId, newProtoManifest.CreationTime );
+
                 if ( Config.DownloadManifestOnly )
                 {
                     StringBuilder manifestBuilder = new StringBuilder();
-                    string txtManifest = Path.Combine( depot.installDir, string.Format( "manifest_{0}.txt", depot.id ) );
+                    string txtManifest = Path.Combine( depot.installDir, string.Format( "manifest_{0}_{1}.txt", depot.id, depot.manifestId ) );
+                    manifestBuilder.Append( string.Format( "{0}\n\n", newProtoManifest.CreationTime ) );
 
                     foreach ( var file in newProtoManifest.Files )
                     {
@@ -749,6 +752,8 @@ namespace DepotDownloader
                             continue;
 
                         manifestBuilder.Append( string.Format( "{0}\n", file.FileName ) );
+                        manifestBuilder.Append( string.Format( "\t{0}\n", file.TotalSize ) );
+                        manifestBuilder.Append( string.Format( "\t{0}\n", BitConverter.ToString( file.FileHash ).Replace( "-", "" ) ) );
                     }
 
                     File.WriteAllText( txtManifest, manifestBuilder.ToString() );

--- a/DepotDownloader/ProtoManifest.cs
+++ b/DepotDownloader/ProtoManifest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 
@@ -20,6 +21,7 @@ namespace DepotDownloader
         {
             sourceManifest.Files.ForEach(f => Files.Add(new FileData(f)));
             ID = id;
+            CreationTime = sourceManifest.CreationTime;
         }
 
         [ProtoContract()]
@@ -116,6 +118,9 @@ namespace DepotDownloader
 
         [ProtoMember(2)]
         public ulong ID { get; private set; }
+
+        [ProtoMember(3)]
+        public DateTime CreationTime { get; private set; }
 
         public static ProtoManifest LoadFromFile(string filename, out byte[] checksum)
         {


### PR DESCRIPTION
* Changed name format of cached manifest files to depotid_manifestid.bin. Better clarity + matches Steam's naming convention.
* manifest-only produces more information now. It puts manifest creation time at the top followed by the list of files with their sizes and hashes.
* The program now prints manifest id and its creation time before downloading depot.