### PR TITLE
Implement per-chunk downloads

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -1081,8 +1081,6 @@ namespace DepotDownloader
 
                 fileStreamData.fileStream.Seek((long)chunkData.ChunkInfo.Offset, SeekOrigin.Begin);
                 fileStreamData.fileStream.Write(chunkData.Data, 0, chunkData.Data.Length);
-
-  
             }
             finally
             {
@@ -1100,6 +1098,7 @@ namespace DepotDownloader
             if (remainingChunks == 0)
             {
                 fileStreamData.fileStream.Dispose();
+                fileStreamData.fileLock.Dispose();
 
                 var fileFinalPath = Path.Combine(depot.installDir, file.FileName);
                 Console.WriteLine("{0,6:#00.00}% {1}", ((float)sizeDownloaded / (float)depotDownloadCounter.CompleteDownloadSize) * 100.0f, fileFinalPath);

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -1088,7 +1088,7 @@ namespace DepotDownloader
                 await fileStreamData.fileLock.WaitAsync().ConfigureAwait(false);
 
                 fileStreamData.fileStream.Seek((long)chunkData.ChunkInfo.Offset, SeekOrigin.Begin);
-                fileStreamData.fileStream.Write(chunkData.Data, 0, chunkData.Data.Length);
+                await fileStreamData.fileStream.WriteAsync(chunkData.Data, 0, chunkData.Data.Length);
             }
             finally
             {

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -108,7 +108,7 @@ namespace DepotDownloader
 
             ContentDownloader.Config.VerifyAll = HasParameter( args, "-verify-all" ) || HasParameter( args, "-verify_all" ) || HasParameter( args, "-validate" );
             ContentDownloader.Config.MaxServers = GetParameter<int>( args, "-max-servers", 20 );
-            ContentDownloader.Config.MaxDownloads = GetParameter<int>( args, "-max-downloads", 4 );
+            ContentDownloader.Config.MaxDownloads = GetParameter<int>( args, "-max-downloads", 8 );
             ContentDownloader.Config.MaxServers = Math.Max( ContentDownloader.Config.MaxServers, ContentDownloader.Config.MaxDownloads );
             ContentDownloader.Config.LoginID = HasParameter( args, "-loginid" ) ? (uint?)GetParameter<uint>( args, "-loginid" ) : null;
 
@@ -341,7 +341,7 @@ namespace DepotDownloader
             Console.WriteLine();
             Console.WriteLine( "\t-manifest-only\t\t\t- downloads a human readable manifest for any depots that would be downloaded." );
             Console.WriteLine( "\t-cellid <#>\t\t\t\t- the overridden CellID of the content server to download from." );
-            Console.WriteLine( "\t-max-servers <#>\t\t- maximum number of content servers to use. (default: 8)." );
+            Console.WriteLine( "\t-max-servers <#>\t\t- maximum number of content servers to use. (default: 20)." );
             Console.WriteLine( "\t-max-downloads <#>\t\t- maximum number of chunks to download concurrently. (default: 4)." );
             Console.WriteLine( "\t-loginid <#>\t\t- a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently." );
         }

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -342,7 +342,7 @@ namespace DepotDownloader
             Console.WriteLine( "\t-manifest-only\t\t\t- downloads a human readable manifest for any depots that would be downloaded." );
             Console.WriteLine( "\t-cellid <#>\t\t\t\t- the overridden CellID of the content server to download from." );
             Console.WriteLine( "\t-max-servers <#>\t\t- maximum number of content servers to use. (default: 20)." );
-            Console.WriteLine( "\t-max-downloads <#>\t\t- maximum number of chunks to download concurrently. (default: 4)." );
+            Console.WriteLine( "\t-max-downloads <#>\t\t- maximum number of chunks to download concurrently. (default: 8)." );
             Console.WriteLine( "\t-loginid <#>\t\t- a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently." );
         }
     }

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -129,16 +129,19 @@ namespace DepotDownloader
         }
 
         public delegate bool WaitCondition();
+        private object steamLock = new object();
         public bool WaitUntilCallback( Action submitter, WaitCondition waiter )
         {
             while ( !bAborted && !waiter() )
             {
-                submitter();
+                lock (steamLock)
+                    submitter();
 
                 int seq = this.seq;
                 do
                 {
-                    WaitForCallbacks();
+                    lock (steamLock)
+                        WaitForCallbacks();
                 }
                 while ( !bAborted && this.seq == seq && !waiter() );
             }
@@ -473,7 +476,7 @@ namespace DepotDownloader
 
         public void TryWaitForLoginKey()
         {
-            if ( logonDetails.Username == null || !ContentDownloader.Config.RememberPassword ) return;
+            if ( logonDetails.Username == null || !credentials.LoggedOn || !ContentDownloader.Config.RememberPassword ) return;
 
             var totalWaitPeriod = DateTime.Now.AddSeconds( 3 );
 
@@ -584,7 +587,7 @@ namespace DepotDownloader
                     }
                     else
                     {
-                        Console.WriteLine( "Login key was expired. Please enter your password: " );
+                        Console.Write( "Login key was expired. Please enter your password: " );
                         logonDetails.Password = Util.ReadPassword();
                     }
                 }

--- a/DepotDownloader/Util.cs
+++ b/DepotDownloader/Util.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace DepotDownloader
 {
@@ -131,6 +132,39 @@ namespace DepotDownloader
             return input.Aggregate( new StringBuilder(),
                 ( sb, v ) => sb.Append( v.ToString( "x2" ) )
                 ).ToString();
+        }
+
+        public static async Task InvokeAsync(IEnumerable<Func<Task>> taskFactories, int maxDegreeOfParallelism)
+        {
+            if (taskFactories == null) throw new ArgumentNullException(nameof(taskFactories));
+            if (maxDegreeOfParallelism <= 0) throw new ArgumentException(nameof(maxDegreeOfParallelism));
+
+            Func<Task>[] queue = taskFactories.ToArray();
+
+            if (queue.Length == 0)
+            {
+                return;
+            }
+
+            List<Task> tasksInFlight = new List<Task>(maxDegreeOfParallelism);
+            int index = 0;
+
+            do
+            {
+                while (tasksInFlight.Count < maxDegreeOfParallelism && index < queue.Length)
+                {
+                    Func<Task> taskFactory = queue[index++];
+
+                    tasksInFlight.Add(taskFactory());
+                }
+
+                Task completedTask = await Task.WhenAny(tasksInFlight).ConfigureAwait(false);
+
+                await completedTask.ConfigureAwait(false);
+
+                tasksInFlight.Remove(completedTask);
+            }
+            while (index < queue.Length || tasksInFlight.Count != 0);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ Parameter | Description
 -validate				| Include checksum verification of files already downloaded
 -manifest-only			| downloads a human readable manifest for any depots that would be downloaded.
 -cellid \<#>			| the overridden CellID of the content server to download from.
--max-servers \<#>		| maximum number of content servers to use. (default: 8).
+-max-servers \<#>		| maximum number of content servers to use. (default: 20).
 -max-downloads \<#>		| maximum number of chunks to download concurrently. (default: 8).
 -loginid \<#>			| a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently.

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ Parameter | Description
 -manifest-only			| downloads a human readable manifest for any depots that would be downloaded.
 -cellid \<#>			| the overridden CellID of the content server to download from.
 -max-servers \<#>		| maximum number of content servers to use. (default: 8).
--max-downloads \<#>		| maximum number of chunks to download concurrently. (default: 4).
+-max-downloads \<#>		| maximum number of chunks to download concurrently. (default: 8).
 -loginid \<#>			| a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently.


### PR DESCRIPTION
- Converts file I/O and chunk downloads into tasks
- File I/O is completed first (that is, we validate all files first)
- Added some additional console messages for the file i/o process like "Validating $file"
- The number of concurrent tasks is now 8 instead of 4.

And a couple fixes inside as well:
- The validation is now done in order (previously it was manifest order, now it's position order)
- oldManifestFileName now correctly matches newManifestFileName (there was a fix for this pending somewhere, but it got lost)