### PR TITLE
Add commandline option `-blacklist-cdn` to blacklist unwanted CDNs.

### DIFF
--- a/DepotDownloader/CDNClientPool.cs
+++ b/DepotDownloader/CDNClientPool.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace DepotDownloader
 {
@@ -27,6 +28,8 @@ namespace DepotDownloader
         private readonly Task monitorTask;
         private readonly CancellationTokenSource shutdownToken;
         public CancellationTokenSource ExhaustedToken { get; set; }
+
+        public static Regex blacklistCDN = new Regex("$^");  // default: a regex that matches nothing.
 
         public CDNClientPool(Steam3Session steamSession)
         {
@@ -97,7 +100,7 @@ namespace DepotDownloader
                         return;
                     }
 
-                    var weightedCdnServers = servers.Where(x => x.Type == "SteamCache" || x.Type == "CDN").Select(x =>
+                    var weightedCdnServers = servers.Where(x => blacklistCDN.Matches(x.Host).Count == 0).Where(x => x.Type == "SteamCache" || x.Type == "CDN").Select(x =>
                     {
                         AccountSettingsStore.Instance.ContentServerPenalty.TryGetValue(x.Host, out var penalty);
 

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -36,6 +36,17 @@ namespace DepotDownloader
                 });
             }
 
+            try
+            {
+                string regex = GetParameter<string>( args, "-blacklist-cdn", "$^" );
+                CDNClientPool.blacklistCDN = new Regex(regex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            }
+            catch
+            {
+                Console.WriteLine( "Error: Invalid regex supplied for -blacklist-cdn" );
+                return 1;
+            }
+
             string username = GetParameter<string>( args, "-username" ) ?? GetParameter<string>( args, "-user" );
             string password = GetParameter<string>( args, "-password" ) ?? GetParameter<string>( args, "-pass" );
             ContentDownloader.Config.RememberPassword = HasParameter( args, "-remember-password" );


### PR DESCRIPTION
Allow users to blacklist CDNs that provide updates only for certain games.
This is a partial solution for #135 .