### PR TITLE
Re-fetch app info after obtaining FreeOnDemand license

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -414,6 +414,9 @@ namespace DepotDownloader
                 if ( steam3.RequestFreeAppLicense( appId ) )
                 {
                     Console.WriteLine( "Obtained FreeOnDemand license for app {0}", appId );
+
+                    // Fetch app info again in case we didn't get it fully without a license.
+                    steam3.RequestAppInfo( appId, true );
                 }
                 else
                 {

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -156,9 +156,9 @@ namespace DepotDownloader
             return credentials;
         }
 
-        public void RequestAppInfo( uint appId )
+        public void RequestAppInfo( uint appId, bool bForce = false )
         {
-            if ( AppInfo.ContainsKey( appId ) || bAborted )
+            if ( ( AppInfo.ContainsKey( appId ) && !bForce ) || bAborted )
                 return;
 
             bool completed = false;
@@ -172,7 +172,7 @@ namespace DepotDownloader
 
                 foreach ( var token_dict in appTokens.AppTokens )
                 {
-                    this.AppTokens.Add( token_dict.Key, token_dict.Value );
+                    this.AppTokens[ token_dict.Key ] = token_dict.Value;
                 }
             };
 
@@ -191,12 +191,12 @@ namespace DepotDownloader
                     var app = app_value.Value;
 
                     Console.WriteLine( "Got AppInfo for {0}", app.ID );
-                    AppInfo.Add( app.ID, app );
+                    AppInfo[ app.ID ] = app;
                 }
 
                 foreach ( var app in appInfo.UnknownApps )
                 {
-                    AppInfo.Add( app, null );
+                    AppInfo[ app ] = null;
                 }
             };
 
@@ -229,12 +229,12 @@ namespace DepotDownloader
                 foreach ( var package_value in packageInfo.Packages )
                 {
                     var package = package_value.Value;
-                    PackageInfo.Add( package.ID, package );
+                    PackageInfo[ package.ID ] = package;
                 }
 
                 foreach ( var package in packageInfo.UnknownPackages )
                 {
-                    PackageInfo.Add( package, null );
+                    PackageInfo[package] = null;
                 }
             };
 


### PR DESCRIPTION
Some FreeOnDemand apps (e.g. 479030) have section_type - ownersonly which means DepotDownloader won't have full app info when it initially tries to fetch it. If it then successfully obtains FreeOnDemand license, it still won't have full app info and the download will fail since there's no depot section. The second run will work fine since DepotDownloader will have full app info now.
I have fixed this issue by forcefully fetching app info again if a FreeOnDemand license is obtained.