### PR TITLE
Updated project to .NET Core 3.1 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ cryptopp/
 
 # misc
 Thumbs.db
+
+# IntelliJ / Rider
+.idea/

--- a/DepotDownloader/DepotDownloader.csproj
+++ b/DepotDownloader/DepotDownloader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DepotDownloader
 ===============
 
-Steam depot downloader utilizing the SteamKit2 library. Supports .NET Core 2.0
+Steam depot downloader utilizing the SteamKit2 library. Supports .NET Core 3.1
 
 ### Downloading one or all depots for an app
 ```


### PR DESCRIPTION
.NET Core 2.0 has reached EOL on 2018-10-01 and does not receive security patches anymore. Upgraded project to the latest LTS release which will receive support until December 2022. (See https://dotnet.microsoft.com/platform/support/policy/dotnet-core)

Also, since I like to use Rider and want to contribute, I added the `.idea` folder to the `.gitignore` so these files don't reach the repo.