### PR TITLE
Normalize slashes in filepath; explicit regex support

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -94,12 +94,13 @@ namespace DepotDownloader
             if ( !Config.UsingFileList )
                 return true;
 
-            foreach ( string fileListEntry in Config.FilesToDownload )
+            filename = filename.Replace( '\\', '/' );
+            
+            if ( Config.FilesToDownload.Contains( filename ) )
             {
-                if ( fileListEntry.Equals( filename, StringComparison.OrdinalIgnoreCase ) )
-                    return true;
+                return true;
             }
-
+            
             foreach ( Regex rgx in Config.FilesToDownloadRegex )
             {
                 Match m = rgx.Match( filename );

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -12,7 +12,7 @@ namespace DepotDownloader
         public string InstallDirectory { get; set; }
 
         public bool UsingFileList { get; set; }
-        public List<string> FilesToDownload { get; set; }
+        public HashSet<string> FilesToDownload { get; set; }
         public List<Regex> FilesToDownloadRegex { get; set; }
 
         public string BetaPassword { get; set; }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Parameter | Description
 -password \<pass>		| the password of the account to login to for restricted content.
 -remember-password		| if set, remember the password for subsequent logins of this user.
 -dir \<installdir>		| the directory in which to place downloaded files.
--filelist \<file.txt>	| a list of files to download (from the manifest). Can optionally use regex to download only certain files.
+-filelist \<file.txt>	| a list of files to download (from the manifest). Prefix file path with `regex:` if you want to match with regex.
 -validate				| Include checksum verification of files already downloaded
 -manifest-only			| downloads a human readable manifest for any depots that would be downloaded.
 -cellid \<#>			| the overridden CellID of the content server to download from.


### PR DESCRIPTION
Fixes #30
Fixes #18
Fixes #17

I opted for `regex:` prefix because otherwise all paths are converted to regex which is not great. This converts all `\` slashes into `/` both in the file list, and when matching (because manifests can contain that sometimes). Windows handles `/` just fine, there is no need to convert it back.