### PR TITLE
Updated manifest-to-text conversion to imitate Steam format

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -907,21 +907,7 @@ namespace DepotDownloader
 
             if (Config.DownloadManifestOnly)
             {
-                StringBuilder manifestBuilder = new StringBuilder();
-                string txtManifest = Path.Combine(depot.installDir, string.Format("manifest_{0}_{1}.txt", depot.id, depot.manifestId));
-                manifestBuilder.Append(string.Format("{0}\n\n", newProtoManifest.CreationTime));
-
-                foreach (var file in newProtoManifest.Files)
-                {
-                    if (file.Flags.HasFlag(EDepotFileFlag.Directory))
-                        continue;
-
-                    manifestBuilder.Append(string.Format("{0}\n", file.FileName));
-                    manifestBuilder.Append(string.Format("\t{0}\n", file.TotalSize));
-                    manifestBuilder.Append(string.Format("\t{0}\n", BitConverter.ToString(file.FileHash).Replace("-", "")));
-                }
-
-                File.WriteAllText(txtManifest, manifestBuilder.ToString());
+                DumpManifestToTextFile(depot, newProtoManifest);
                 return null;
             }
 
@@ -1294,6 +1280,49 @@ namespace DepotDownloader
                 Console.WriteLine("{0,6:#00.00}% {1}", ((float)sizeDownloaded / (float)depotDownloadCounter.CompleteDownloadSize) * 100.0f, fileFinalPath);
             }
 
+        }
+
+        static void DumpManifestToTextFile( DepotDownloadInfo depot, ProtoManifest manifest )
+        {
+            var txtManifest = Path.Combine( depot.installDir, $"manifest_{depot.id}_{depot.manifestId}.txt" );
+
+            using ( var sw = new StreamWriter( txtManifest ) )
+            {
+                sw.WriteLine( $"Content Manifest for Depot {depot.id}" );
+                sw.WriteLine();
+                sw.WriteLine( $"Manifest ID / date     : {depot.manifestId} / {manifest.CreationTime}" );
+
+                int numFiles = 0, numChunks = 0;
+                ulong uncompressedSize = 0, compressedSize = 0;
+
+                foreach ( var file in manifest.Files )
+                {
+                    if ( file.Flags.HasFlag( EDepotFileFlag.Directory ) )
+                        continue;
+
+                    numFiles++;
+                    numChunks += file.Chunks.Count;
+
+                    foreach ( var chunk in file.Chunks )
+                    {
+                        uncompressedSize += chunk.UncompressedLength;
+                        compressedSize += chunk.CompressedLength;
+                    }
+                }
+
+                sw.WriteLine( $"Total number of files  : {numFiles}" );
+                sw.WriteLine( $"Total number of chunks : {numChunks}" );
+                sw.WriteLine( $"Total bytes on disk    : {uncompressedSize}" );
+                sw.WriteLine( $"Total bytes compressed : {compressedSize}" );
+                sw.WriteLine();
+                sw.WriteLine( "          Size Chunks File SHA                                 Flags Name" );
+
+                foreach ( var file in manifest.Files )
+                {
+                    var sha1Hash = BitConverter.ToString( file.FileHash ).Replace( "-", "" );
+                    sw.WriteLine( $"{file.TotalSize,14} {file.Chunks.Count,6} {sha1Hash} {file.Flags,5:D} {file.FileName}" );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The new format sticks closely to Steam's dump_manifest command output.

Sample:
```
Content Manifest for Depot 232250

Manifest ID / date     : 556842576136773479 / 02.03.2021 19:07:27
Total number of files  : 837
Total number of chunks : 9134
Total bytes on disk    : 8349997016
Total bytes compressed : 4271885904

          Size Chunks File SHA                                 Flags Name
          1740      1 E5A60917270AB34F05A5DC4EDB1479B357D0AFF7     0 bin\basehaptics.txt
     119280838    122 C5FF2D876CB1CC918A31AFD5B76AE978BBA01C15     0 hl2\hl2_misc_000.vpk
     116673308    117 6F6E7EBC25D270DD5681043E7098FD93A36F5B4F     0 hl2\hl2_misc_001.vpk
     112736030    113 757BAA5FA13AC772D7479FD85E6F12DC35CBD688     0 hl2\hl2_misc_002.vpk
     121877968    128 773EFAA7E263B7FEB57B287840100D6A882CA042     0 hl2\hl2_misc_003.vpk
        721800      1 A0BB7C35FCFD0FB2D54F2A20D96CD720B2D72B35     0 hl2\hl2_misc_dir.vpk
      20868868     20 E521080D6A40344CFB26B51B58EF0501FD885425     0 hl2\hl2_sound_misc.vpk.sound.cache
        113317      1 D4038DEBDB0B09FD894323809A3A390B064E978E     0 hl2\hl2_sound_misc_dir.vpk
      29164433     28 DB75345D0067BB1851918FBEE20E73DCD7819E01     0 hl2\hl2_sound_vo_english.vpk.sound.cache
         97210      1 24E25273B0D1F3B32ABE4EC4C488F0EB46E9FA1D     0 hl2\hl2_sound_vo_english_dir.vpk
        213663      1 9596617E1A72426A56A2EDE1134D30E075BE2FEB     0 hl2\hl2_textures_dir.vpk
             0      0 0000000000000000000000000000000000000000    40 hl2\media
             0      0 0000000000000000000000000000000000000000    40 hl2\resource
           326      1 691E70C8A6B37EA06AAF071609E2A6E4C1C01F83     0 hl2\resource\block.cur
         55464      1 2FEB2B0E5FF9D9BAB4A5E5ECA949F87A8DC278CB     0 hl2\resource\boxrocket.ttf
. . .
```