### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.trx
+**/*.md

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -29,11 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        id: qemu
         uses: docker/setup-qemu-action@v2
-        with:
-          # architectures supported by the .NET runtime
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -74,4 +70,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ steps.qemu.platforms }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,7 +24,7 @@ jobs:
     name: Docker image
     runs-on: ubuntu-latest
     env:
-      DOCKER_USERNAME: "dumbasPL"
+      DOCKER_USERNAME: "SteamRE"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -29,9 +29,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up QEMU
+        id: qemu
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: amd64,arm64,arm
+          # architectures supported by the .NET runtime
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -72,4 +74,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
+          platforms: ${{ steps.qemu.platforms }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,75 @@
+name: Docker CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+    paths-ignore:
+      - '.github/*'
+      - '.github/*_TEMPLATE/**'
+      - '*.md'
+  pull_request:
+    branches:
+      - 'master'
+    paths-ignore:
+      - '.github/*'
+      - '.github/*_TEMPLATE/**'
+      - '*.md'
+
+jobs:
+  build:
+    name: Docker image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: "dumbasPL"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: amd64,arm64,arm
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.DOCKER_USERNAME }}/DepotDownloader
+            ghcr.io/${{ env.DOCKER_USERNAME }}/DepotDownloader
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+        
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -70,4 +70,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          # platforms: linux/amd64,linux/arm/v7,linux/arm64/v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+WORKDIR /DepotDownloader
+
+COPY ./ ./
+
+RUN dotnet restore
+
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+WORKDIR /DepotDownloader
+
+COPY --from=build /DepotDownloader/out .
+
+ENTRYPOINT ["dotnet", "DepotDownloader.dll"]


### PR DESCRIPTION
This PR adds a `Dockerfile` as well as CI to build and publish the file to docker hub and GitHub container registry. closes #404 

The ci automatically builds and publishes images for all pushes to the master branch (under the `master` doker tag) as well as only builds (but does not push) images for every pull request to the master branch. On top of that, it builds versioned releases for every version tag in the format of `v2.4.7` as well as updates the `latest` docker tag whenever there is a versioned release.

To make this work maintainers need to set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets on the repository or organization as well as enable write access to the Github token used in actions to allow it to push to ghcr.io

Multi-platform builds have been temporarily disabled since .NET 6.0 isn't ready for them yet and improved ways of building them have only recently become available.

ref: https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/