### PR TITLE
Add support for appinfo depots section with expanded branch info.

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -244,7 +244,7 @@ namespace DepotDownloader
             if (manifests.Children.Count == 0 && manifests_encrypted.Children.Count == 0)
                 return INVALID_MANIFEST_ID;
 
-            var node = manifests[branch];
+            var node = manifests[branch].Children.Count > 0 ? manifests[branch]["gid"] : manifests[branch];
 
             if (branch != "Public" && node == KeyValue.Invalid)
             {


### PR DESCRIPTION
Some apps are now seeing a change in the manifests format in app info.

In the manifests configuration for non-shared depots, the branch key's value expands into multiple pieces of information (including manifest gid) rather than the value solely being the manifest gid itself.

This change adds support for the newer structure.

Example of previous format:

```
		"732"
		{
			"manifests"
			{
				"public"		"3227301410759530897"
			}
		}
```


Example of new format:

```
		"2401941"
		{
			"manifests"
			{
				"public"
				{
					"gid"		"8167810549604512812"
					"size"		"641749089"
					"download"		"400816672"
				}
			}
		}
```