### PR TITLE
Bump .net to 8.0, remove deprecated SentryData and add GuardData

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Build
-        run: dotnet publish -c ${{ matrix.configuration }} -o artifacts
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj -c ${{ matrix.configuration }} -o artifacts
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -45,31 +45,31 @@ jobs:
 
       - name: Publish Windows-x64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'windows-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime win-x64 --output selfcontained-win-x64
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime win-x64 --output selfcontained-win-x64
 
       - name: Publish Windows-arm64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'windows-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime win-arm64 --output selfcontained-win-arm64
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime win-arm64 --output selfcontained-win-arm64
 
       - name: Publish Linux-x64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-x64 --output selfcontained-linux-x64
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-x64 --output selfcontained-linux-x64
 
       - name: Publish Linux-arm
         if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-arm --output selfcontained-linux-arm
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-arm --output selfcontained-linux-arm
 
       - name: Publish Linux-arm64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-arm64 --output selfcontained-linux-arm64
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-arm64 --output selfcontained-linux-arm64
 
       - name: Publish macOS-x64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'macos-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime osx-x64 --output selfcontained-osx-x64
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime osx-x64 --output selfcontained-osx-x64
 
       - name: Publish macOS-arm64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'macos-latest'
-        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime osx-arm64 --output selfcontained-osx-arm64
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime osx-arm64 --output selfcontained-osx-arm64
 
       - name: Upload Windows-x64
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Build
         run: dotnet publish -c ${{ matrix.configuration }} -o artifacts

--- a/.github/workflows/sk2-ci.yml
+++ b/.github/workflows/sk2-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Configure NuGet
         run: |

--- a/DepotDownloader/AccountSettingsStore.cs
+++ b/DepotDownloader/AccountSettingsStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -11,8 +11,7 @@ namespace DepotDownloader
     [ProtoContract]
     class AccountSettingsStore
     {
-        [ProtoMember(1, IsRequired = false)]
-        public Dictionary<string, byte[]> SentryData { get; private set; }
+        // Member 1 was a Dictionary<string, byte[]> for SentryData.
 
         [ProtoMember(2, IsRequired = false)]
         public ConcurrentDictionary<string, int> ContentServerPenalty { get; private set; }
@@ -22,13 +21,16 @@ namespace DepotDownloader
         [ProtoMember(4, IsRequired = false)]
         public Dictionary<string, string> LoginTokens { get; private set; }
 
+        [ProtoMember(5, IsRequired = false)]
+        public Dictionary<string, string> GuardData { get; private set; }
+
         string FileName;
 
         AccountSettingsStore()
         {
-            SentryData = new Dictionary<string, byte[]>();
             ContentServerPenalty = new ConcurrentDictionary<string, int>();
             LoginTokens = new Dictionary<string, string>();
+            GuardData = new Dictionary<string, string>();
         }
 
         static bool Loaded

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -1163,7 +1163,7 @@ namespace DepotDownloader
                     neededChunks = Util.ValidateSteam3FileChecksums(fs, file.Chunks.OrderBy(x => x.Offset).ToArray());
                 }
 
-                if (neededChunks.Count() == 0)
+                if (neededChunks.Count == 0)
                 {
                     lock (depotDownloadCounter)
                     {

--- a/DepotDownloader/DepotDownloader.csproj
+++ b/DepotDownloader/DepotDownloader.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <RollForward>LatestMajor</RollForward>
     <Version>2.5.0</Version>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.2.16" />
+    <PackageReference Include="protobuf-net" Version="3.2.26" />
     <PackageReference Include="QRCoder" Version="1.4.3" />
     <PackageReference Include="SteamKit2" Version="2.5.0-Beta.1" />
   </ItemGroup>

--- a/DepotDownloader/HttpDiagnosticEventListener.cs
+++ b/DepotDownloader/HttpDiagnosticEventListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.Tracing;
 using System.Text;
 
@@ -35,7 +35,7 @@ namespace DepotDownloader
                 }
             }
 
-            sb.Append(")");
+            sb.Append(')');
             Console.WriteLine(sb.ToString());
         }
     }

--- a/DepotDownloader/ProtoManifest.cs
+++ b/DepotDownloader/ProtoManifest.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Security.Cryptography;
 using ProtoBuf;
 using SteamKit2;
 
@@ -135,7 +136,7 @@ namespace DepotDownloader
                 using (var ds = new DeflateStream(fs, CompressionMode.Decompress))
                     ds.CopyTo(ms);
 
-                checksum = Util.SHAHash(ms.ToArray());
+                checksum = SHA1.HashData(ms.ToArray());
 
                 ms.Seek(0, SeekOrigin.Begin);
                 return Serializer.Deserialize<ProtoManifest>(ms);
@@ -148,7 +149,7 @@ namespace DepotDownloader
             {
                 Serializer.Serialize(ms, this);
 
-                checksum = Util.SHAHash(ms.ToArray());
+                checksum = SHA1.HashData(ms.ToArray());
 
                 ms.Seek(0, SeekOrigin.Begin);
 

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -118,7 +118,7 @@ namespace DepotDownloader
             if (details.Username != null)
             {
                 // Reused what was done for sentryFile but does this has any use ?
-                var fi = new FileInfo(String.Format("{0}.guardDataFile", logonDetails.Username));
+                var fi = new FileInfo(string.Format("{0}.guardDataFile", logonDetails.Username));
                 if (AccountSettingsStore.Instance.GuardData != null && !AccountSettingsStore.Instance.GuardData.ContainsKey(logonDetails.Username) && fi.Exists && fi.Length > 0)
                 {
                     var guardData = File.ReadAllText(fi.FullName);
@@ -503,8 +503,7 @@ namespace DepotDownloader
                     {
                         try
                         {
-                            string guarddata = null;
-                            _ = AccountSettingsStore.Instance.GuardData.TryGetValue(logonDetails.Username, out guarddata);
+                            _ = AccountSettingsStore.Instance.GuardData.TryGetValue(logonDetails.Username, out var guarddata);
                             authSession = await steamClient.Authentication.BeginAuthSessionViaCredentialsAsync(new SteamKit2.Authentication.AuthSessionDetails
                             {
                                 Username = logonDetails.Username,

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -211,9 +211,9 @@ namespace DepotDownloader
             };
 
             var request = new SteamApps.PICSRequest(appId);
-            if (AppTokens.ContainsKey(appId))
+            if (AppTokens.TryGetValue(appId, out var value))
             {
-                request.AccessToken = AppTokens[appId];
+                request.AccessToken = value;
             }
 
             WaitUntilCallback(() =>
@@ -656,7 +656,7 @@ namespace DepotDownloader
                     {
                         Console.Write("Please enter your 2 factor auth code from your authenticator app: ");
                         logonDetails.TwoFactorCode = Console.ReadLine();
-                    } while (String.Empty == logonDetails.TwoFactorCode);
+                    } while (string.Empty == logonDetails.TwoFactorCode);
                 }
                 else if (isAccessToken)
                 {

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -115,18 +115,6 @@ namespace DepotDownloader
 
             Console.Write("Connecting to Steam3...");
 
-            if (details.Username != null)
-            {
-                // Reused what was done for sentryFile but does this has any use ?
-                var fi = new FileInfo(string.Format("{0}.guardDataFile", logonDetails.Username));
-                if (AccountSettingsStore.Instance.GuardData != null && !AccountSettingsStore.Instance.GuardData.ContainsKey(logonDetails.Username) && fi.Exists && fi.Length > 0)
-                {
-                    var guardData = File.ReadAllText(fi.FullName);
-                    AccountSettingsStore.Instance.GuardData[logonDetails.Username] = guardData;
-                    AccountSettingsStore.Save();
-                }
-            }
-
             Connect();
         }
 

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -198,9 +198,9 @@ namespace DepotDownloader
             };
 
             var request = new SteamApps.PICSRequest(appId);
-            if (AppTokens.TryGetValue(appId, out var value))
+            if (AppTokens.TryGetValue(appId, out var token))
             {
-                request.AccessToken = value;
+                request.AccessToken = token;
             }
 
             WaitUntilCallback(() =>

--- a/DepotDownloader/Steam3Session.cs
+++ b/DepotDownloader/Steam3Session.cs
@@ -560,8 +560,14 @@ namespace DepotDownloader
                         logonDetails.Password = null;
                         logonDetails.AccessToken = result.RefreshToken;
 
-                        // Should i check if guardData is null ?
-                        AccountSettingsStore.Instance.GuardData[result.AccountName] = result.NewGuardData;
+                        if (result.NewGuardData != null)
+                        {
+                            AccountSettingsStore.Instance.GuardData[result.AccountName] = result.NewGuardData;
+                        }
+                        else
+                        {
+                            AccountSettingsStore.Instance.GuardData.Remove(result.AccountName);
+                        }
                         AccountSettingsStore.Instance.LoginTokens[result.AccountName] = result.RefreshToken;
                         AccountSettingsStore.Save();
                     }

--- a/DepotDownloader/Util.cs
+++ b/DepotDownloader/Util.cs
@@ -136,7 +136,7 @@ namespace DepotDownloader
         public static async Task InvokeAsync(IEnumerable<Func<Task>> taskFactories, int maxDegreeOfParallelism)
         {
             ArgumentNullException.ThrowIfNull(taskFactories);
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(0, maxDegreeOfParallelism);
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxDegreeOfParallelism, 0);
 
             var queue = taskFactories.ToArray();
 

--- a/DepotDownloader/Util.cs
+++ b/DepotDownloader/Util.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -113,13 +112,6 @@ namespace DepotDownloader
             return BitConverter.GetBytes(a | (b << 16));
         }
 
-        public static byte[] SHAHash(byte[] input)
-        {
-            var output = SHA1.HashData(input);
-
-            return output;
-        }
-
         public static byte[] DecodeHexString(string hex)
         {
             if (hex == null)
@@ -144,7 +136,7 @@ namespace DepotDownloader
         public static async Task InvokeAsync(IEnumerable<Func<Task>> taskFactories, int maxDegreeOfParallelism)
         {
             ArgumentNullException.ThrowIfNull(taskFactories);
-            if (maxDegreeOfParallelism <= 0) throw new ArgumentException(nameof(maxDegreeOfParallelism));
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(0, maxDegreeOfParallelism);
 
             var queue = taskFactories.ToArray();
 

--- a/DepotDownloader/Util.cs
+++ b/DepotDownloader/Util.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -115,12 +115,9 @@ namespace DepotDownloader
 
         public static byte[] SHAHash(byte[] input)
         {
-            using (var sha = SHA1.Create())
-            {
-                var output = sha.ComputeHash(input);
+            var output = SHA1.HashData(input);
 
-                return output;
-            }
+            return output;
         }
 
         public static byte[] DecodeHexString(string hex)
@@ -146,7 +143,7 @@ namespace DepotDownloader
 
         public static async Task InvokeAsync(IEnumerable<Func<Task>> taskFactories, int maxDegreeOfParallelism)
         {
-            if (taskFactories == null) throw new ArgumentNullException(nameof(taskFactories));
+            ArgumentNullException.ThrowIfNull(taskFactories);
             if (maxDegreeOfParallelism <= 0) throw new ArgumentException(nameof(maxDegreeOfParallelism));
 
             var queue = taskFactories.ToArray();

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Bumps .net to 8.0
Bumps protobuf-net to 3.2.26 to be in sync with SteamKit 2.5.0 ( closes #432 )

[Fix CA1834](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1834)

Removes deprecated SentryData usage and sort of replaces it with GuardData (i was unable to test this part since i don't have an account with mail Steam guard on hand)
Replaces .sentryFile handling with .guardDataFile but i don't think it has any use so i guess i should simply remove that part ?

