### PR TITLE
Add public modifier to 3 classes to enable linking

### DIFF
--- a/DepotDownloader/AccountSettingsStore.cs
+++ b/DepotDownloader/AccountSettingsStore.cs
@@ -12,7 +12,7 @@ using ProtoBuf;
 namespace DepotDownloader
 {
     [ProtoContract]
-    class AccountSettingsStore
+    public class AccountSettingsStore
     {
         // Member 1 was a Dictionary<string, byte[]> for SentryData.
 

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -15,11 +15,11 @@ using SteamKit2.CDN;
 
 namespace DepotDownloader
 {
-    class ContentDownloaderException(string value) : Exception(value)
+    public class ContentDownloaderException(string value) : Exception(value)
     {
     }
 
-    static class ContentDownloader
+    public static class ContentDownloader
     {
         public const uint INVALID_APP_ID = uint.MaxValue;
         public const uint INVALID_DEPOT_ID = uint.MaxValue;

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 
 namespace DepotDownloader
 {
-    class DownloadConfig
+    public class DownloadConfig
     {
         public int CellID { get; set; }
         public bool DownloadAllPlatforms { get; set; }


### PR DESCRIPTION
Setting these 3 classes as public allows another C# app to link to the exe and use the it as a reference to download files.
Enables my feature request - https://github.com/SteamRE/DepotDownloader/issues/557