### PR TITLE
build.yml: Add MUSL LibC runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,18 @@ jobs:
         if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
         run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-arm64 --output selfcontained-linux-arm64
 
+      - name: Publish Linux-musl-x64
+        if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-musl-x64 --output selfcontained-linux-musl-x64
+
+      - name: Publish Linux-musl-arm
+        if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-musl-arm --output selfcontained-linux-musl-arm
+
+      - name: Publish Linux-musl-arm64
+        if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
+        run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime linux-musl-arm64 --output selfcontained-linux-musl-arm64
+
       - name: Publish macOS-x64
         if: matrix.configuration == 'Release' && matrix.runs-on == 'macos-latest'
         run: dotnet publish DepotDownloader/DepotDownloader.csproj --configuration Release -p:PublishSingleFile=true -p:DebugType=embedded --self-contained --runtime osx-x64 --output selfcontained-osx-x64
@@ -111,6 +123,30 @@ jobs:
           path: selfcontained-linux-arm64
           if-no-files-found: error
 
+      - name: Upload Linux-musl-x64
+        uses: actions/upload-artifact@v4
+        if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
+        with:
+          name: DepotDownloader-linux-musl-x64
+          path: selfcontained-linux-musl-x64
+          if-no-files-found: error
+
+      - name: Upload Linux-musl-arm
+        uses: actions/upload-artifact@v4
+        if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
+        with:
+          name: DepotDownloader-linux-musl-arm
+          path: selfcontained-linux-musl-arm
+          if-no-files-found: error
+
+      - name: Upload Linux-musl-arm64
+        uses: actions/upload-artifact@v4
+        if: matrix.configuration == 'Release' && matrix.runs-on == 'ubuntu-latest'
+        with:
+          name: DepotDownloader-linux-musl-arm64
+          path: selfcontained-linux-musl-arm64
+          if-no-files-found: error
+
       - name: Upload macOS-x64
         uses: actions/upload-artifact@v4
         if: matrix.configuration == 'Release' && matrix.runs-on == 'macos-latest'
@@ -148,6 +184,9 @@ jobs:
         chmod +x artifacts/DepotDownloader-linux-x64/DepotDownloader
         chmod +x artifacts/DepotDownloader-linux-arm/DepotDownloader
         chmod +x artifacts/DepotDownloader-linux-arm64/DepotDownloader
+        chmod +x artifacts/DepotDownloader-linux-musl-x64/DepotDownloader
+        chmod +x artifacts/DepotDownloader-linux-musl-arm/DepotDownloader
+        chmod +x artifacts/DepotDownloader-linux-musl-arm64/DepotDownloader
         chmod +x artifacts/DepotDownloader-macos-x64/DepotDownloader
         chmod +x artifacts/DepotDownloader-macos-arm64/DepotDownloader
         zip -9j release/DepotDownloader-framework.zip artifacts/DepotDownloader-framework/*
@@ -156,6 +195,9 @@ jobs:
         zip -9j release/DepotDownloader-linux-x64.zip artifacts/DepotDownloader-linux-x64/*
         zip -9j release/DepotDownloader-linux-arm.zip artifacts/DepotDownloader-linux-arm/*
         zip -9j release/DepotDownloader-linux-arm64.zip artifacts/DepotDownloader-linux-arm64/*
+        zip -9j release/DepotDownloader-linux-musl-x64.zip artifacts/DepotDownloader-linux-musl-x64/*
+        zip -9j release/DepotDownloader-linux-musl-arm.zip artifacts/DepotDownloader-linux-musl-arm/*
+        zip -9j release/DepotDownloader-linux-musl-arm64.zip artifacts/DepotDownloader-linux-musl-arm64/*
         zip -9j release/DepotDownloader-macos-x64.zip artifacts/DepotDownloader-macos-x64/*
         zip -9j release/DepotDownloader-macos-arm64.zip artifacts/DepotDownloader-macos-arm64/*
 


### PR DESCRIPTION
Because it would be nice to have it actions runner and grab singlefile binary directly instead of building it yourself.
Tested on Alpine Linux and worked as intended. Probably will work on distros that used MUSL LibC.

All requests is welcomed if I did something wrong.