### PR TITLE
Warn and trim password to 64 characters.

### DIFF
--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -358,6 +358,14 @@ namespace DepotDownloader
                 }
             }
 
+
+            if (password != null && password.Length > 64)
+            {
+                Console.WriteLine("Notice: password is longer than 64 characters and will be trimmed.");
+                password = password.Substring(0, 64);
+            }
+
+
             return ContentDownloader.InitializeSteam3(username, password);
         }
 


### PR DESCRIPTION
Steam will trim passwords longer than 64 characters.

Reference: #597.