### PR TITLE
Fix getting manifest code for freetodownload apps that use depotfromapp

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -603,10 +603,17 @@ namespace DepotDownloader
                 return null;
             }
 
-            // For depots that are proxied through depotfromapp, we still need to resolve the proxy app id
+            // For depots that are proxied through depotfromapp, we still need to resolve the proxy app id, unless the app is freetodownload
             var containingAppId = appId;
             var proxyAppId = GetSteam3DepotProxyAppId(depotId, appId);
-            if (proxyAppId != INVALID_APP_ID) containingAppId = proxyAppId;
+            if (proxyAppId != INVALID_APP_ID)
+            {
+                var common = GetSteam3AppSection(appId, EAppInfoSection.Common);
+                if (common == null || !common["FreeToDownload"].AsBoolean())
+                {
+                    containingAppId = proxyAppId;
+                }
+            }
 
             return new DepotDownloadInfo(depotId, containingAppId, manifestId, branch, installDir, depotKey);
         }


### PR DESCRIPTION
Fixes #609 

Tested on:
* Black Mesa Dedicated Server (freetodownload) - 346680
* Half-Life 2 (not free) - 220

Both use `depotfromapp`