### PR TITLE
Add -output-json option to output -manifest-only as JSON

### DIFF
--- a/DepotDownloader/DepotDownloader.csproj
+++ b/DepotDownloader/DepotDownloader.csproj
@@ -28,5 +28,6 @@
     <PackageReference Include="protobuf-net" Version="3.2.56" />
     <PackageReference Include="QRCoder" Version="1.7.0" />
     <PackageReference Include="SteamKit2" Version="3.3.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -32,5 +32,6 @@ namespace DepotDownloader
 
         public bool UseQrCode { get; set; }
         public bool SkipAppConfirmation { get; set; }
+        public bool OutputJson { get; set; }
     }
 }

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -156,6 +156,7 @@ namespace DepotDownloader
 
             ContentDownloader.Config.MaxDownloads = GetParameter(args, "-max-downloads", 8);
             ContentDownloader.Config.LoginID = HasParameter(args, "-loginid") ? GetParameter<uint>(args, "-loginid") : null;
+            ContentDownloader.Config.OutputJson = HasParameter(args, "-output-json") || HasParameter(args, "-json");
 
             #endregion
 
@@ -529,6 +530,7 @@ namespace DepotDownloader
             Console.WriteLine("  -max-downloads <#>       - maximum number of chunks to download concurrently. (default: 8).");
             Console.WriteLine("  -loginid <#>             - a unique 32-bit integer Steam LogonID in decimal, required if running multiple instances of DepotDownloader concurrently.");
             Console.WriteLine("  -use-lancache            - forces downloads over the local network via a Lancache instance.");
+            Console.WriteLine("  -output-json             - outputs -manifest-only manifest as JSON.");
             Console.WriteLine();
             Console.WriteLine("  -debug                   - enable verbose debug logging.");
             Console.WriteLine("  -V or --version          - print version and runtime.");

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Parameter               | Description
 `-cellid <#>`           | the overridden CellID of the content server to download from.
 `-max-downloads <#>`    | maximum number of chunks to download concurrently. (default: 8).
 `-use-lancache`         | forces downloads over the local network via a Lancache instance.
+`-output-json`          | outputs -manifest-only manifest as JSON.
 
 #### Other
 


### PR DESCRIPTION
# Description
Adds the option to output the manifest data as `.json`, by extending the current feature: `-manifest-only`

This was added to allow consumption of manifest data in automation suites that can parse JSON.

# Changes:
* Adds the `System.Text.Json` Nuget package
* Adds the option `-output-json` with the short alias: `-json`
* Adds new entries to `README.md` and the command line help

# In use
* Example: `depotdownloader -app 555000 dir "D:/dd/test" -username MY_USER -remember-password -manifest-only -output-json`
* Will write `manifest_1726842_9033940306086386405.json` to disk instead of `manifest_1726842_9033940306086386405.txt`

This is the `.json` output:
```json
{
    "description": "Content Manifest for Depot 1726841",
    "depotId": 1726841,
    "manifestId": 5411008570503528000,
    "manifestCreationTime": "2021-12-02T19:29:43Z",
    "totalFiles": 5,
    "totalChunks": 51,
    "totalBytesOnDisk": 50856840,
    "totalBytesCompressed": 50806528,
    "files": [
        {
            "size": 3182256,
            "chunks": 4,
            "sha": "636810d800da741e76de59778159b18c36e7f0ef",
            "flags": "0",
            "name": "01 - Lights, Camera, Violence! (Main Theme).mp3"
        },
        {
            "size": 17502648,
            "chunks": 17,
            "sha": "6c7e5e28d5951074cce5f8cf42e03dbe80d2ef54",
            "flags": "0",
            "name": "02 - Vindication Syndication (Gameshow Ambient).mp3"
        },
        {
            "size": 19351488,
            "chunks": 19,
            "sha": "c17c2909bc13f17f5ab316adf8b3592e354aa4c1",
            "flags": "0",
            "name": "03 - Broadcast Beatdown (Gameshow Battle).mp3"
        },
        {
            "size": 5120544,
            "chunks": 5,
            "sha": "6aea593ace53e874e2cfc8c2113cf8cdb56dd52b",
            "flags": "0",
            "name": "04 - Lovely Parting Gifts (Boss Battle).mp3"
        },
        {
            "size": 5699904,
            "chunks": 6,
            "sha": "5cfb24abd773d773b49eb11d0603a9ea06c1fc69",
            "flags": "0",
            "name": "05 - Chainsaw Swagger (Da Champ).mp3"
        }
    ]
}
```
Which is modeled after the original manifest output:
```
Content Manifest for Depot 1726841 

Manifest ID / date     : 5411008570503528439 / 12/02/2021 19:29:43 
Total number of files  : 5 
Total number of chunks : 51 
Total bytes on disk    : 50856840 
Total bytes compressed : 50806528 


          Size Chunks File SHA                                 Flags Name
       3182256      4 636810d800da741e76de59778159b18c36e7f0ef     0 01 - Lights, Camera, Violence! (Main Theme).mp3
      17502648     17 6c7e5e28d5951074cce5f8cf42e03dbe80d2ef54     0 02 - Vindication Syndication (Gameshow Ambient).mp3
      19351488     19 c17c2909bc13f17f5ab316adf8b3592e354aa4c1     0 03 - Broadcast Beatdown (Gameshow Battle).mp3
       5120544      5 6aea593ace53e874e2cfc8c2113cf8cdb56dd52b     0 04 - Lovely Parting Gifts (Boss Battle).mp3
       5699904      6 5cfb24abd773d773b49eb11d0603a9ea06c1fc69     0 05 - Chainsaw Swagger (Da Champ).mp3
```
I realize now while looking at this that the JSON renderer does not use the same date format, not sure if that is a problem or not.

# Testing
* Functionality was verified through a custom test suite that did deep matching of the original output and the new JSON output across 1000+ depots (until I got ratelimited).