### PR TITLE
Fix Windows 10 LTSC panic/crash due to kernel missing CET features

### DIFF
--- a/DepotDownloader/DepotDownloader.csproj
+++ b/DepotDownloader/DepotDownloader.csproj
@@ -12,6 +12,7 @@
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TreatWarningsAsErrors>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <CetCompat>false</CetCompat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/67f24888-cf2a-4d45-989b-5ef1cb60d9c4" />
<img width="460" height="423" alt="image" src="https://github.com/user-attachments/assets/1069e973-c82d-4673-8556-f7dd30e21c94" />


Windows 10 IoT LTSC and older Windows 10 builds don’t support Control-flow Enforcement Technology (CET).
CET’s Shadow Stack feature helps defend against return-oriented programming (ROP) attacks, but since these systems lack CET support, disabling CET compatibility causes no loss of security or functionality in this program btw