### PR TITLE
Allow multiple manifests to be downloaded from the same depot

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -58,7 +58,7 @@ namespace DepotDownloader
             public byte[] DepotKey { get; } = depotKey;
         }
 
-        static bool CreateDirectories(uint depotId, uint depotVersion, out string installDir)
+        static bool CreateDirectories(uint depotId, uint depotVersion, ulong manifestId, out string installDir)
         {
             installDir = null;
             try
@@ -78,9 +78,14 @@ namespace DepotDownloader
                 }
                 else
                 {
-                    Directory.CreateDirectory(Config.InstallDirectory);
+                    // Allow substitution in the specified install directory
+                    installDir = Config.InstallDirectory
+                        .Replace("%(depot_id)", depotId.ToString())
+                        .Replace("%(depot_version)", depotVersion.ToString())
+                        .Replace("%(manifest_id)", manifestId.ToString())
+                    ;
 
-                    installDir = Config.InstallDirectory;
+                    Directory.CreateDirectory(installDir);
 
                     Directory.CreateDirectory(Path.Combine(installDir, CONFIG_DIR));
                     Directory.CreateDirectory(Path.Combine(installDir, STAGING_DIR));
@@ -422,7 +427,7 @@ namespace DepotDownloader
 
         private static async Task DownloadWebFile(uint appId, string fileName, string url)
         {
-            if (!CreateDirectories(appId, 0, out var installDir))
+            if (!CreateDirectories(appId, 0, 0, out var installDir))
             {
                 Console.WriteLine("Error: Unable to create install directories!");
                 return;
@@ -639,7 +644,7 @@ namespace DepotDownloader
 
             var uVersion = GetSteam3AppBuildNumber(appId, branch);
 
-            if (!CreateDirectories(depotId, uVersion, out var installDir))
+            if (!CreateDirectories(depotId, uVersion, manifestId, out var installDir))
             {
                 Console.WriteLine("Error: Unable to create install directories!");
                 return null;

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -568,7 +568,7 @@ namespace DepotDownloader
                     throw new ContentDownloaderException(string.Format("Couldn't find any depots to download for app {0}", appId));
                 }
 
-                if (depotIdsFound.Count < depotIdsExpected.Count)
+                if (!depotIdsExpected.All(depotIdsFound.Contains))
                 {
                     var remainingDepotIds = depotIdsExpected.Except(depotIdsFound);
                     throw new ContentDownloaderException(string.Format("Depot {0} not listed for app {1}", string.Join(", ", remainingDepotIds), appId));

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -461,7 +461,11 @@ namespace DepotDownloader
             cdnPool = new CDNClientPool(steam3, appId);
 
             // Load our configuration data containing the depots currently installed
-            var configPath = Config.InstallDirectory;
+            var configPath = Config.InstallDirectory
+                .Replace("%(depot_id)", "0")
+                .Replace("%(depot_version)", "0")
+                .Replace("%(manifest_id)", "0")
+            ;
             if (string.IsNullOrWhiteSpace(configPath))
             {
                 configPath = DEFAULT_DOWNLOAD_DIR;

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -733,18 +733,33 @@ namespace DepotDownloader
                 cts.Token.ThrowIfCancellationRequested();
             }
 
-            // If we're about to write all the files to the same directory, we will need to first de-duplicate any files by path
+            // If we're about to write multiple manifests to the same directory, we will need to first de-duplicate any files by path
             // This is in last-depot-wins order, from Steam or the list of depots supplied by the user
-            if (!string.IsNullOrWhiteSpace(Config.InstallDirectory) && depotsToDownload.Count > 0)
+            var installLocations = depotsToDownload
+                .GroupBy((depot) => depot.depotDownloadInfo.InstallDir)
+                .ToDictionary((group) => group.Key, (group) => group.Count());
+
+            if (installLocations.Any((pair) => pair.Value > 1) && depotsToDownload.Count > 0)
             {
-                var claimedFileNames = new HashSet<string>();
+                var claimedFileNames = new Dictionary<string, HashSet<string>>();
 
                 for (var i = depotsToDownload.Count - 1; i >= 0; i--)
                 {
-                    // For each depot, remove all files from the list that have been claimed by a later depot
-                    depotsToDownload[i].filteredFiles.RemoveAll(file => claimedFileNames.Contains(file.FileName));
+                    var depot = depotsToDownload[i];
 
-                    claimedFileNames.UnionWith(depotsToDownload[i].allFileNames);
+                    if (!claimedFileNames.TryGetValue(depot.depotDownloadInfo.InstallDir, out var claimedSet))
+                    {
+                        // If this is the first depot to be downloaded into this directory, it gets to claim the full list
+                        claimedFileNames.Add(depot.depotDownloadInfo.InstallDir, depot.allFileNames);
+                    }
+                    else
+                    {
+                        // Remove files that have been claimed by a later depot
+                        depot.filteredFiles.RemoveAll(file => claimedSet.Contains(file.FileName));
+
+                        // Add files owned by this depot to the claimed set
+                        claimedSet.UnionWith(depot.allFileNames);
+                    }
                 }
             }
 

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -461,14 +461,14 @@ namespace DepotDownloader
             cdnPool = new CDNClientPool(steam3, appId);
 
             // Load our configuration data containing the depots currently installed
-            var configPath = Config.InstallDirectory
-                .Replace("%(depot_id)", "0")
-                .Replace("%(depot_version)", "0")
-                .Replace("%(manifest_id)", "0")
-            ;
-            if (string.IsNullOrWhiteSpace(configPath))
+            var configPath = DEFAULT_DOWNLOAD_DIR;
+            if (!string.IsNullOrWhiteSpace(Config.InstallDirectory))
             {
-                configPath = DEFAULT_DOWNLOAD_DIR;
+                configPath = Config.InstallDirectory
+                    .Replace("%(depot_id)", "0")
+                    .Replace("%(depot_version)", "0")
+                    .Replace("%(manifest_id)", "0")
+                ;
             }
 
             Directory.CreateDirectory(Path.Combine(configPath, CONFIG_DIR));

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -293,14 +293,22 @@ namespace DepotDownloader
                 var manifestIdList = GetParameterList<ulong>(args, "-manifest");
                 if (manifestIdList.Count > 0)
                 {
-                    if (depotIdList.Count != manifestIdList.Count)
+                    if (depotIdList.Count == 1 && manifestIdList.Count > 1)
+                    {
+                        Console.WriteLine($"Only one depot ID was provided, but multiple manifest IDs were provided. Assuming all manifests are part of depot {depotIdList[0]}");
+                        var zippedDepotManifest = manifestIdList.Select((manifestId) => (depotIdList[0], manifestId));
+                        depotManifestIds.AddRange(zippedDepotManifest);
+                    }
+                    else if (depotIdList.Count == manifestIdList.Count)
+                    {
+                        var zippedDepotManifest = depotIdList.Zip(manifestIdList, (depotId, manifestId) => (depotId, manifestId));
+                        depotManifestIds.AddRange(zippedDepotManifest);
+                    }
+                    else
                     {
                         Console.WriteLine("Error: -manifest requires one id for every -depot specified");
                         return 1;
                     }
-
-                    var zippedDepotManifest = depotIdList.Zip(manifestIdList, (depotId, manifestId) => (depotId, manifestId));
-                    depotManifestIds.AddRange(zippedDepotManifest);
                 }
                 else
                 {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ By default it will use anonymous account ([view which apps are available on it h
 To use your account, specify the `-username <username>` parameter. Password will be asked interactively if you do
 not use specify the `-password` parameter.
 
+### Downloading multiple manifests
+
+You can specify additional depot+manifest pairs by adding multiple arguments to `-depot` and `-manifest`.
+```powershell
+./DepotDownloader -app <id> -depot <id1> <id2> -manifest <id1> <id2>
+                 [-username <username> [-password <password>]] [other options]
+```
+
+For example: `./DepotDownloader -app 730 -depot 731 732 -manifest 7617088375292372759 1021596294116939367`
+
+The first manifest ID is downloaded from the first depot ID, and so on.
+So for this example, it would download manifest `7617088375292372759` from depot `731` and manifest `1021596294116939367` from depot `732`.
+
+If you only specify one depot ID and multiple manifest IDs, it will download those manifests from the same depot ID.
+To prevent them being downloaded into the same folder, you can use variable substitution with `-dir`:
+`./DepotDownloader -app 730 -depot 731 -manifest 7617088375292372759 4899579212072880822 -dir "depots/%(depot_id)/%(manifest_id)"`
+
 ### Downloading a workshop item using pubfile id
 ```powershell
 ./DepotDownloader -app <id> -pubfile <id> [-username <username> [-password <password>]]
@@ -95,7 +112,7 @@ Parameter               | Description
 `-all-languages`        | download all language-specific depots when `-app` is used.
 `-language <lang>`      | the language for which to download the game (default: english)
 `-lowviolence`          | download low violence depots when `-app` is used.
-`-dir <installdir>`     | the directory in which to place downloaded files.
+`-dir <installdir>`     | the directory in which to place downloaded files. You can use `%(depot_id)`, `%(depot_version)` and `%(manifest_id)` to substitute these values into the path.
 `-filelist <file.txt>`  | the name of a local file that contains a list of files to download (from the manifest). prefix file path with `regex:` if you want to match with regex. each file path should be on their own line.
 `-validate`             | include checksum verification of files already downloaded.
 `-manifest-only`        | downloads a human readable manifest for any depots that would be downloaded.


### PR DESCRIPTION
# Rationale
I want to be able to download multiple versions of a game from a depot, without having to manually do each manifest at a time and without hitting authentication rate limits as brought up in #674.

# Problems
There are currently 3 problems that prevent download of multiple manifests from one depot:

## Problem 1
Typing `-depot 1 -manifest 2 3` produces "Error: -manifest requires one id for every -depot specified"

This is mostly a user experience thing, but if you wanted to e.g. download 4 manifests you would need to do `-depot 1 1 1 1 -manifest 2 3 4 5` which is slightly annoying.

This PR fixes this by detecting if exactly one depot ID is specified with multiple manifest IDs, and then uses that depot ID for all manifests (and produces a message so the user knows what's happening).

## Problem 2
Typing `-depot 1 1 -manifest 2 3` produces "Depot  not listed for app 1"

This happens because DepotDownloader tries to validate that all depots requested were retrieved by comparing the length of the retrieved list with the provided list. It deduplicates depots retrieved, so in this case it will compare `[1, 1]` with `[1]` and conclude that not all depots were retrieved, failing the download.

This PR fixes it by instead checking that all IDs within `depotIdsExpected` are *contained* within `depotIdsFound`, working even if there are duplicate IDs.

## Problem 3
The default output directory does not have subdirectories for manifests, so manifests with the same depot ID will be downloaded to the same place. In addition, specifying your own directory will just download ALL of the contents into the same folder.

This PR fixes it by allowing `-dir` to have substitution variables `%(depot_id)`, `%(depot_version)` and `%(manifest_id)`. This means you can do e.g. `-depot 1 -manifest 2 3 4 -dir "depots/%(depot_id)/%(manifest_id)"` to have it output each manifest into a different directory.

## Problem 4
DepotDownloader assumes that either deduplication is not necessary if `-dir` is not passed, or that it is necessary and will do it across all files if `-dir` is passed.

This means even if the outputs would go into separate directories due to the string interpolation implemented before, it will still ignore files that have the same name, producing manifest folders with incomplete installs.

This PR fixes it by rewriting the deduplication code to deduplicate only within `DepotDownloadInfo`s that target the exact same output folder. This means deduplication still works in all prior supported cases, but won't prevent the same files being written if they are going to different folders.

This does have the caveat that identical files might be downloaded multiple times, but I'm not sure if there is a good way to detect this before the download has happened, and I think it would add a lot of complexity and need for rewriting. I think the implementation as is works for my use case, and people are free to make a follow-up PR if they think this is important enough.

# Caveats
The config for DepotDownloader is usually either placed in the root of `depots/` or in the location given by `-dir`. The config is shared across all of the downloads, so it doesn't belong to any specific depot or manifest ID.

To deal with this, this PR just substitutes all of the variables with `0` for the config directory. This creates an extra, potentially pretty confusing, directory, but it does allow all downloads who use the same `-dir` format to share a config without issue.

I think this is not an ideal solution but I didn't want to make any unintentional breaking changes so this is the workaround for that.