### PR TITLE
Add exponential backoff to downloads

### DIFF
--- a/DepotDownloader/Backoff.cs
+++ b/DepotDownloader/Backoff.cs
@@ -1,0 +1,44 @@
+// This file is subject to the terms and conditions defined
+// in file 'LICENSE', which is part of this source code package.
+
+using System;
+using System.Threading.Tasks;
+
+namespace DepotDownloader
+{
+    class Backoff
+    {
+        public readonly double ScalingFactor;
+        public readonly double MinDelayS;
+        public readonly double MaxDelayS;
+        public int Attempts = 0;
+
+        public Backoff(double MinDelayS = 1.0, double MaxDelayS = 120.0, double ScalingFactor = 1.3)
+        {
+            this.MinDelayS = MinDelayS;
+            this.MaxDelayS = MaxDelayS;
+            this.ScalingFactor = ScalingFactor;
+        }
+
+        public void RecordAttempt()
+        {
+            this.Attempts += 1;
+        }
+
+        public Task Sleep()
+        {
+            if (Attempts == 0)
+            {
+                return Task.Delay(0);
+            }
+            var sleepTimeS = MinDelayS * Math.Pow(ScalingFactor, Attempts - 1);
+            if (sleepTimeS > MaxDelayS)
+            {
+                sleepTimeS = MaxDelayS;
+            }
+            var sleepTimeMS = (int)Math.Round(sleepTimeS * 1000.0);
+            Console.WriteLine($"Waiting {sleepTimeS:F2} seconds");
+            return Task.Delay(sleepTimeMS);
+        }
+    }
+}

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -794,9 +794,13 @@ namespace DepotDownloader
                     ulong manifestRequestCode = 0;
                     var manifestRequestCodeExpiration = DateTime.MinValue;
 
+                    var backoff = new Backoff();
+
                     do
                     {
                         cts.Token.ThrowIfCancellationRequested();
+
+                        backoff.RecordAttempt();
 
                         Server connection = null;
 
@@ -850,7 +854,7 @@ namespace DepotDownloader
                         }
                         catch (TaskCanceledException)
                         {
-                            Console.WriteLine("Connection timeout downloading depot manifest {0} {1}. Retrying.", depot.DepotId, depot.ManifestId);
+                            Console.WriteLine("Connection timeout downloading depot manifest {0} {1}", depot.DepotId, depot.ManifestId);
                         }
                         catch (SteamKitWebRequestException e)
                         {
@@ -889,6 +893,9 @@ namespace DepotDownloader
                             cdnPool.ReturnBrokenConnection(connection);
                             Console.WriteLine("Encountered error downloading manifest for depot {0} {1}: {2}", depot.DepotId, depot.ManifestId, e.Message);
                         }
+
+                        Console.WriteLine("Retrying.");
+                        await backoff.Sleep();
                     } while (newManifest == null);
 
                     if (newManifest == null)
@@ -1244,9 +1251,12 @@ namespace DepotDownloader
 
             try
             {
+                var backoff = new Backoff();
                 do
                 {
                     cts.Token.ThrowIfCancellationRequested();
+
+                    backoff.RecordAttempt();
 
                     Server connection = null;
 
@@ -1313,6 +1323,9 @@ namespace DepotDownloader
                         cdnPool.ReturnBrokenConnection(connection);
                         Console.WriteLine("Encountered unexpected error downloading chunk {0}: {1}", chunkID, e.Message);
                     }
+
+                    Console.WriteLine("Retrying.");
+                    await backoff.Sleep();
                 } while (written == 0);
 
                 if (written == 0)


### PR DESCRIPTION
Sometimes the API thinks you're doing too many requests and so returns an error; continuing to repeat the request many times per second is a great way to make the steam server not like you very much.

This adds a simple exponential backoff when attempting to grab a manifest and when downloading chunks.

It waits 1.3 ^ (attempts so far - 1) seconds up to a maximum of 120 seconds. As a table, the wait times looks like this:

 n | time in seconds that it will wait after the nth request
---|-------
 1 |   1.00
 2 |   1.30
 3 |   1.69
 4 |   2.20
 5 |   2.86
 6 |   3.71
 7 |   4.83
 8 |   6.27
 9 |   8.16
10 |  10.60
11 |  13.79
12 |  17.92
13 |  23.30
14 |  30.29
15 |  39.37
16 |  51.19
17 |  66.54
18 |  86.50
19 | 112.46
20+| 120.00

----

Note: The numbers here (min 1s, exponent 1.3, max 120s) were chose somewhat on vibes. They seem roughly right to me, but if you have a better idea I'm happy to change it.