### PR TITLE
Fix all files being set as executable

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -1202,14 +1202,7 @@ namespace DepotDownloader
             }
 
             var fileIsExecutable = file.Flags.HasFlag(EDepotFileFlag.Executable);
-            if (fileIsExecutable && (!fileDidExist || oldManifestFile == null || !oldManifestFile.Flags.HasFlag(EDepotFileFlag.Executable)))
-            {
-                PlatformUtilities.SetExecutable(fileFinalPath, true);
-            }
-            else if (!fileIsExecutable && oldManifestFile != null && oldManifestFile.Flags.HasFlag(EDepotFileFlag.Executable))
-            {
-                PlatformUtilities.SetExecutable(fileFinalPath, false);
-            }
+            PlatformUtilities.SetExecutable(fileFinalPath, fileIsExecutable);
 
             var fileStreamData = new FileStreamData
             {


### PR DESCRIPTION
I'm not sure what the old code was trying to do exactly, but the effect was that every file was set as executable. This just sets the executable bit based on that flag in the manifest.